### PR TITLE
normalizes invalid ts values (None/blank) before insert, and clamps i…

### DIFF
--- a/ambientweather2sqlite/configuration.py
+++ b/ambientweather2sqlite/configuration.py
@@ -126,13 +126,8 @@ def create_config_file(
     *,
     overwrite_existing: bool = False,
 ) -> Path:
-    if (
-        not overwrite_existing
-        and config_path is not None
-        and (output_path := Path(config_path))
-        and output_path.exists()
-    ):
-        return output_path
+    if not overwrite_existing and config_path is not None and Path(config_path).exists():
+        return Path(config_path)
 
     print("Configuration Setup")
     print("-" * 20)
@@ -164,6 +159,8 @@ def create_config_file(
     if port:
         config += f"port = {port}\n"
     output_path = Path(output_file)
+    if not overwrite_existing and output_path.exists():
+        return output_path
     output_path.write_text(config, encoding="utf-8")
 
     return output_path

--- a/ambientweather2sqlite/database.py
+++ b/ambientweather2sqlite/database.py
@@ -58,7 +58,9 @@ def _prepare_observation(
     observation: Observation,
 ) -> dict[str, str | int | float | None]:
     prepared = dict(observation)
-    prepared.setdefault(_TS_COL, _current_observation_timestamp())
+    ts_value = prepared.get(_TS_COL)
+    if not isinstance(ts_value, str) or not ts_value.strip():
+        prepared[_TS_COL] = _current_observation_timestamp()
     return prepared
 
 
@@ -206,11 +208,11 @@ def _normalize_hourly_date_range(
     timezone: str | ZoneInfo,
 ) -> tuple[date, date]:
     start_date_obj = _parse_query_date(start_date)
-    end_date_obj = (
-        _parse_query_date(end_date)
-        if end_date is not None
-        else _current_date_for_timezone(timezone)
-    )
+    if end_date is None:
+        candidate_end_date = _current_date_for_timezone(timezone)
+        end_date_obj = max(candidate_end_date, start_date_obj)
+    else:
+        end_date_obj = _parse_query_date(end_date)
 
     if end_date_obj < start_date_obj:
         raise InvalidDateRangeError(

--- a/ambientweather2sqlite/scanner.py
+++ b/ambientweather2sqlite/scanner.py
@@ -11,10 +11,46 @@ from ambientweather2sqlite import mureq
 from ambientweather2sqlite.awparser import extract_values
 
 
+def _non_loopback_ipv4_candidates() -> list[str]:
+    try:
+        _, _, addresses = socket.gethostbyname_ex(socket.gethostname())
+    except OSError:
+        addresses = []
+    candidates = [
+        address for address in addresses if not address.startswith("127.")
+    ]
+    if candidates:
+        return candidates
+
+    try:
+        addrinfos = socket.getaddrinfo(
+            socket.gethostname(),
+            None,
+            family=socket.AF_INET,
+        )
+    except OSError:
+        addrinfos = []
+
+    candidates.extend(
+        address_info[4][0]
+        for address_info in addrinfos
+        if not address_info[4][0].startswith("127.")
+    )
+
+    return list(dict.fromkeys(candidates))
+
+
 def _detect_local_ip() -> str:
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-        s.connect(("8.8.8.8", 80))
-        return s.getsockname()[0]
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except OSError:
+        for candidate in _non_loopback_ipv4_candidates():
+            return candidate
+
+    msg = "Unable to detect local IPv4 address"
+    raise RuntimeError(msg)
 
 
 def _prefix_length_from_ifconfig(output: str, local_ip: str) -> int | None:
@@ -68,7 +104,7 @@ def _detect_prefix_length(local_ip: str) -> int | None:
         ):
             continue
 
-        if prefix_length := parser(result.stdout):
+        if (prefix_length := parser(result.stdout)) is not None:
             return prefix_length
 
     return None
@@ -77,7 +113,9 @@ def _detect_prefix_length(local_ip: str) -> int | None:
 def detect_local_subnet() -> str:
     """Detect the local subnet by finding the machine's default route IP."""
     local_ip = _detect_local_ip()
-    prefix_length = _detect_prefix_length(local_ip) or 24
+    prefix_length = _detect_prefix_length(local_ip)
+    if prefix_length is None:
+        prefix_length = 24
     network = ipaddress.ip_network(f"{local_ip}/{prefix_length}", strict=False)
     return str(network)
 
@@ -156,7 +194,7 @@ def scan_for_stations(subnet: str | None = None) -> list[str]:
             subnet = detect_local_subnet()
         except (OSError, ValueError) as exc:
             print(f"Unable to auto-detect local subnet: {exc}")
-            return []
+            raise
 
     print(f"Scanning {subnet} for devices with port 80 open...")
     open_hosts = scan_port80(subnet)

--- a/tests/test_configuration_wizard.py
+++ b/tests/test_configuration_wizard.py
@@ -169,6 +169,52 @@ class TestCreateConfigFile(TestCase):
             self.assertIn("http://192.168.0.99/livedata.htm", content)
 
     @patch("builtins.input")
+    def test_returns_existing_default_path_without_overwriting(self, mock_input):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            current_path = Path(temp_dir)
+            config_path = current_path / "aw2sqlite.toml"
+            config_path.write_text("existing", encoding="utf-8")
+            mock_input.side_effect = [
+                "n",
+                "http://192.168.0.99/livedata.htm",
+                str(current_path / "replacement.db"),
+                "",
+                "",
+            ]
+
+            with patch(
+                "ambientweather2sqlite.configuration._CURRENT_PATH",
+                current_path,
+            ):
+                result = create_config_file(None)
+
+            self.assertEqual(result, config_path)
+            self.assertEqual(result.read_text(encoding="utf-8"), "existing")
+
+    @patch("builtins.input")
+    def test_returns_existing_prompted_path_without_overwriting(self, mock_input):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            current_path = Path(temp_dir)
+            output_path = current_path / "existing.toml"
+            output_path.write_text("existing", encoding="utf-8")
+            mock_input.side_effect = [
+                "n",
+                "http://192.168.0.99/livedata.htm",
+                str(current_path / "replacement.db"),
+                "",
+                str(output_path),
+            ]
+
+            with patch(
+                "ambientweather2sqlite.configuration._CURRENT_PATH",
+                current_path,
+            ):
+                result = create_config_file(None)
+
+            self.assertEqual(result, output_path)
+            self.assertEqual(result.read_text(encoding="utf-8"), "existing")
+
+    @patch("builtins.input")
     def test_creates_config_file_with_manual_url(self, mock_input):
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "aw2sqlite.toml"
@@ -264,10 +310,14 @@ class TestCreateConfigFile(TestCase):
             content = result.read_text(encoding="utf-8")
             self.assertIn("http://192.168.0.20/livedata.htm", content)
 
-    @patch("ambientweather2sqlite.scanner.scan_for_stations")
     @patch("builtins.input")
-    def test_falls_back_to_manual_url_when_auto_scan_fails(self, mock_input, mock_scan):
-        mock_scan.side_effect = OSError("offline")
+    @patch("ambientweather2sqlite.scanner.detect_local_subnet")
+    def test_falls_back_to_manual_url_when_auto_scan_fails(
+        self,
+        mock_detect,
+        mock_input,
+    ):
+        mock_detect.side_effect = OSError("offline")
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = Path(temp_dir) / "aw2sqlite.toml"
             mock_input.side_effect = [

--- a/tests/test_daemon_integration.py
+++ b/tests/test_daemon_integration.py
@@ -5,6 +5,7 @@ import sqlite3
 import tempfile
 import threading
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import closing
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -104,15 +105,15 @@ class TestDaemonIntegration(TestCase):
             time.sleep(0.2)
         return False
 
-    def _run_single_cycle_daemon(self) -> None:
-        try:
-            start_daemon(
-                self.live_data_url,
-                self.db_path,
-                period_seconds=1,
-            )
-        except SystemExit as exc:
-            self.assertEqual(exc.code, 0)
+    def _run_single_cycle_daemon(self) -> tuple[ThreadPoolExecutor, Future[None]]:
+        executor = ThreadPoolExecutor(max_workers=1)
+        daemon_future = executor.submit(
+            start_daemon,
+            self.live_data_url,
+            self.db_path,
+            period_seconds=1,
+        )
+        return executor, daemon_future
 
     def test_daemon_single_cycle_inserts_observation(self):
         """Run the daemon for a single cycle and verify data is inserted."""
@@ -120,15 +121,21 @@ class TestDaemonIntegration(TestCase):
             "ambientweather2sqlite.daemon.wait_for_next_update",
             side_effect=KeyboardInterrupt,
         ):
-            daemon_thread = threading.Thread(
-                target=self._run_single_cycle_daemon,
-            )
-            daemon_thread.start()
+            executor, daemon_future = self._run_single_cycle_daemon()
             row_observed = self._wait_for_row_count()
-            daemon_thread.join(timeout=2)
+            daemon_exit = None
+            try:
+                daemon_future.result(timeout=2)
+            except SystemExit as exc:
+                daemon_exit = exc
+            finally:
+                executor.shutdown(wait=True)
 
         self.assertTrue(row_observed)
-        self.assertFalse(daemon_thread.is_alive())
+        self.assertTrue(daemon_future.done())
+        self.assertIsInstance(daemon_exit, SystemExit)
+        if isinstance(daemon_exit, SystemExit):
+            self.assertEqual(daemon_exit.code, 0)
 
         # Verify the inserted data has expected columns
         with closing(sqlite3.connect(self.db_path)) as conn:
@@ -147,15 +154,21 @@ class TestDaemonIntegration(TestCase):
             "ambientweather2sqlite.daemon.wait_for_next_update",
             side_effect=KeyboardInterrupt,
         ):
-            daemon_thread = threading.Thread(
-                target=self._run_single_cycle_daemon,
-            )
-            daemon_thread.start()
+            executor, daemon_future = self._run_single_cycle_daemon()
             row_observed = self._wait_for_row_count()
-            daemon_thread.join(timeout=2)
+            daemon_exit = None
+            try:
+                daemon_future.result(timeout=2)
+            except SystemExit as exc:
+                daemon_exit = exc
+            finally:
+                executor.shutdown(wait=True)
 
         self.assertTrue(row_observed)
-        self.assertFalse(daemon_thread.is_alive())
+        self.assertTrue(daemon_future.done())
+        self.assertIsInstance(daemon_exit, SystemExit)
+        if isinstance(daemon_exit, SystemExit):
+            self.assertEqual(daemon_exit.code, 0)
 
         result = query_daily_aggregated_data(
             db_path=self.db_path,

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 from contextlib import closing
 from pathlib import Path
+from unittest.mock import patch
 
 from ambientweather2sqlite.database import (
     _column_name,
@@ -143,16 +144,54 @@ class TestDatabaseUtilityFunctions(unittest.TestCase):
     def test_insert_observation_without_ts_uses_unique_precise_timestamps(self):
         create_database_if_not_exists(self.db_path)
 
-        insert_observation(self.db_path, {"outTemp": 75.0})
-        insert_observation(self.db_path, {"outTemp": 76.0})
+        with patch(
+            "ambientweather2sqlite.database._current_observation_timestamp",
+            side_effect=[
+                "2026-01-01 12:00:00.000001",
+                "2026-01-01 12:00:00.000002",
+            ],
+        ):
+            insert_observation(self.db_path, {"outTemp": 75.0})
+            insert_observation(self.db_path, {"outTemp": 76.0})
 
         with closing(sqlite3.connect(self.db_path)) as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT COUNT(*), COUNT(DISTINCT ts) FROM observations")
-            count, distinct_ts = cursor.fetchone()
+            cursor.execute("SELECT ts FROM observations ORDER BY ts")
+            timestamps = [row[0] for row in cursor.fetchall()]
 
-        self.assertEqual(count, 2)
-        self.assertEqual(distinct_ts, 2)
+        self.assertEqual(
+            timestamps,
+            [
+                "2026-01-01 12:00:00.000001",
+                "2026-01-01 12:00:00.000002",
+            ],
+        )
+
+    def test_insert_observation_normalizes_invalid_ts_values(self):
+        create_database_if_not_exists(self.db_path)
+
+        with patch(
+            "ambientweather2sqlite.database._current_observation_timestamp",
+            side_effect=[
+                "2026-01-01 12:00:00.000010",
+                "2026-01-01 12:00:00.000011",
+            ],
+        ):
+            insert_observation(self.db_path, {"ts": None, "outTemp": 75.0})
+            insert_observation(self.db_path, {"ts": "   ", "outTemp": 76.0})
+
+        with closing(sqlite3.connect(self.db_path)) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT ts FROM observations ORDER BY ts")
+            timestamps = [row[0] for row in cursor.fetchall()]
+
+        self.assertEqual(
+            timestamps,
+            [
+                "2026-01-01 12:00:00.000010",
+                "2026-01-01 12:00:00.000011",
+            ],
+        )
 
     def test_create_database_migrates_duplicate_timestamps(self):
         with closing(sqlite3.connect(self.db_path)) as conn:

--- a/tests/test_database_timezone.py
+++ b/tests/test_database_timezone.py
@@ -4,6 +4,7 @@ from contextlib import closing
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from ambientweather2sqlite.database import (
@@ -239,6 +240,23 @@ class TestDatabaseTimezone(TestCase):
             start_date=str(self.tomorrow),
             end_date=str(self.tomorrow),
             tz="America/New_York",
+        )
+
+        self.assertEqual(result, {str(self.tomorrow): [None] * 24})
+
+    @patch("ambientweather2sqlite.database._current_date_for_timezone")
+    def test_query_hourly_aggregated_data_clamps_implicit_end_date_to_start_date(
+        self,
+        mock_current_date,
+    ):
+        """Test omitted end_date does not fail when fixed offsets lag behind UTC."""
+        mock_current_date.return_value = self.today
+
+        result = query_hourly_aggregated_data(
+            db_path=self.db_path,
+            aggregation_fields=["avg_outTemp"],
+            start_date=str(self.tomorrow),
+            tz="-08:00",
         )
 
         self.assertEqual(result, {str(self.tomorrow): [None] * 24})

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2,6 +2,8 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from ambientweather2sqlite.scanner import (
+    _detect_local_ip,
+    _detect_prefix_length,
     detect_local_subnet,
     probe_weather_station,
     scan_for_stations,
@@ -35,6 +37,100 @@ class TestDetectLocalSubnet(TestCase):
             ),
         ):
             self.assertEqual(detect_local_subnet(), "192.168.16.0/20")
+
+    def test_respects_zero_prefix_length(self):
+        with (
+            patch(
+                "ambientweather2sqlite.scanner._detect_prefix_length",
+                return_value=0,
+            ),
+            patch(
+                "ambientweather2sqlite.scanner._detect_local_ip",
+                return_value="192.168.16.42",
+            ),
+        ):
+            self.assertEqual(detect_local_subnet(), "0.0.0.0/0")
+
+
+class TestDetectLocalIp(TestCase):
+    @patch("ambientweather2sqlite.scanner.socket.getaddrinfo")
+    @patch("ambientweather2sqlite.scanner.socket.gethostbyname_ex")
+    @patch("ambientweather2sqlite.scanner.socket.socket")
+    def test_falls_back_to_hostname_lookup_when_route_probe_fails(
+        self,
+        mock_socket_cls,
+        mock_gethostbyname_ex,
+        mock_getaddrinfo,
+    ):
+        mock_sock = MagicMock()
+        mock_sock.connect.side_effect = OSError("no route")
+        mock_socket_cls.return_value.__enter__.return_value = mock_sock
+        mock_socket_cls.return_value.__exit__.return_value = False
+        mock_gethostbyname_ex.return_value = (
+            "host",
+            [],
+            ["127.0.0.1", "192.168.1.42"],
+        )
+
+        self.assertEqual(_detect_local_ip(), "192.168.1.42")
+        mock_getaddrinfo.assert_not_called()
+
+    @patch("ambientweather2sqlite.scanner.socket.getaddrinfo")
+    @patch("ambientweather2sqlite.scanner.socket.gethostbyname_ex")
+    @patch("ambientweather2sqlite.scanner.socket.socket")
+    def test_falls_back_to_getaddrinfo_when_hostname_lookup_is_loopback_only(
+        self,
+        mock_socket_cls,
+        mock_gethostbyname_ex,
+        mock_getaddrinfo,
+    ):
+        mock_sock = MagicMock()
+        mock_sock.connect.side_effect = OSError("no route")
+        mock_socket_cls.return_value.__enter__.return_value = mock_sock
+        mock_socket_cls.return_value.__exit__.return_value = False
+        mock_gethostbyname_ex.return_value = ("host", [], ["127.0.0.1"])
+        mock_getaddrinfo.return_value = [
+            (
+                2,
+                1,
+                6,
+                "",
+                ("10.0.0.5", 0),
+            ),
+        ]
+
+        self.assertEqual(_detect_local_ip(), "10.0.0.5")
+
+    @patch("ambientweather2sqlite.scanner.socket.getaddrinfo", return_value=[])
+    @patch(
+        "ambientweather2sqlite.scanner.socket.gethostbyname_ex",
+        return_value=("host", [], ["127.0.0.1"]),
+    )
+    @patch("ambientweather2sqlite.scanner.socket.socket")
+    def test_raises_when_no_non_loopback_ipv4_is_available(
+        self,
+        mock_socket_cls,
+        mock_gethostbyname_ex,
+        mock_getaddrinfo,
+    ):
+        mock_sock = MagicMock()
+        mock_sock.connect.side_effect = OSError("no route")
+        mock_socket_cls.return_value.__enter__.return_value = mock_sock
+        mock_socket_cls.return_value.__exit__.return_value = False
+
+        with self.assertRaisesRegex(RuntimeError, "Unable to detect local IPv4 address"):
+            _detect_local_ip()
+
+        mock_gethostbyname_ex.assert_called_once()
+        mock_getaddrinfo.assert_called_once()
+
+
+class TestDetectPrefixLength(TestCase):
+    @patch("ambientweather2sqlite.scanner.subprocess.run")
+    def test_preserves_zero_prefix_length(self, mock_run):
+        mock_run.return_value.stdout = "2: en0    inet 192.168.1.42/0 brd 192.168.1.255"
+
+        self.assertEqual(_detect_prefix_length("192.168.1.42"), 0)
 
 
 class TestScanPort80(TestCase):
@@ -121,9 +217,8 @@ class TestScanForStations(TestCase):
         self.assertEqual(result, [])
 
     @patch("ambientweather2sqlite.scanner.detect_local_subnet")
-    def test_returns_empty_when_subnet_autodetect_fails(self, mock_detect):
+    def test_raises_when_subnet_autodetect_fails(self, mock_detect):
         mock_detect.side_effect = OSError("no route")
 
-        result = scan_for_stations()
-
-        self.assertEqual(result, [])
+        with self.assertRaisesRegex(OSError, "no route"):
+            scan_for_stations()


### PR DESCRIPTION
…mplicit hourly end_date so negative UTC offsets no longer make omitted end_date fall before start_date

  - configuration.py: stops create_config_file() from overwriting an existing default or prompted output path when overwrite_existing=False.
  - scanner.py: adds non-loopback IPv4 fallback when the 8.8.8.8 route probe fails, preserves prefix length 0, and re-raises subnet autodetect failures instead of flattening them into [].

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize invalid `ts` values and clamp hourly date ranges before database insert
> - Fixes `_prepare_observation` in [database.py](https://github.com/hbmartin/ambientweather2sqlite/pull/23/files#diff-878de80721ba6450d19d824238d36bbbfc4e396c8e318c7bbcad642486a7c28f) to replace missing, non-string, or blank `ts` values with a generated current timestamp instead of storing them as-is.
> - Fixes `_normalize_hourly_date_range` to clamp an auto-computed `end_date` to `start_date` when the current timezone date is earlier, preventing invalid date range errors.
> - Improves local IP detection in [scanner.py](https://github.com/hbmartin/ambientweather2sqlite/pull/23/files#diff-bdf5c0d2f0e795796f2406ae9aa10345620ef087ea4cccfc22402bd1902cddd9) with a hostname-based IPv4 fallback when the UDP route probe fails, and raises `RuntimeError` instead of returning an empty list on autodetect failure.
> - Fixes `_detect_prefix_length` and `detect_local_subnet` to preserve a detected prefix length of `0` rather than treating it as unknown and defaulting to `/24`.
> - Behavioral Change: `scan_for_stations` now raises the underlying exception on subnet autodetect failure instead of silently returning an empty list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3fb1b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp handling to preserve existing values instead of overwriting them
  * Fixed date range validation to ensure end dates don't precede start dates
  * Improved IP detection fallback with graceful error handling when autodetection fails

* **New Features**
  * Added protection to prevent accidental overwriting of existing configuration files
  * Exposed IP detection utilities in the public API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->